### PR TITLE
Bootstrap image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+__backend__.tf
+.nullstone/active-workspace.yml

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ override.tf.json
 # example: *tfplan*
 __backend__.tf
 .nullstone/active-workspace.yml
+
+.terraform.lock.hcl

--- a/.nullstone/module.yml
+++ b/.nullstone/module.yml
@@ -2,8 +2,8 @@ org_name: nullstone
 name: aws-lambda-container-service
 friendly_name: Lambda Service (Container)
 description: Creates a Lambda application using an ECR docker registry.
-category: ""
-subcategory: ""
+category: app
+subcategory: serverless
 provider_types:
     - aws
 platform: lambda

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+publish-bootstrap-image:
+	docker build -t nullstone/lambda-bootstrap:latest .
+	docker push nullstone/lambda-bootstrap:latest

--- a/app.tf
+++ b/app.tf
@@ -7,3 +7,15 @@ data "ns_app_env" "this" {
 locals {
   app_version = data.ns_app_env.this.version
 }
+
+locals {
+  app_metadata = tomap({
+    // Inject app metadata into capabilities here (e.g. security_group_name, role_name)
+    function_arn      = aws_lambda_function.this.arn
+    function_name     = local.resource_name
+    role_name         = aws_iam_role.executor.name
+    role_arn          = aws_iam_role.executor.arn
+    security_group_id = aws_security_group.this.id
+    log_group_name    = module.logs.name
+  })
+}

--- a/bootstrap_image.tf
+++ b/bootstrap_image.tf
@@ -1,0 +1,16 @@
+data "aws_ecr_authorization_token" "temporary" {
+  registry_id = data.aws_caller_identity.this.account_id
+}
+
+provider "dockerless" {
+  registry_auth {
+    address  = data.aws_ecr_authorization_token.temporary.proxy_endpoint
+    username = data.aws_ecr_authorization_token.temporary.user_name
+    password = data.aws_ecr_authorization_token.temporary.password
+  }
+}
+
+resource "dockerless_remote_image" "bootstrap" {
+  source = "nullstone/lambda-bootstrap:latest"
+  target = "${aws_ecr_repository.this.repository_url}:bootstrap"
+}

--- a/bootstrap_image.tf
+++ b/bootstrap_image.tf
@@ -13,5 +13,5 @@ provider "dockerless" {
 
 resource "dockerless_remote_image" "bootstrap" {
   source = "nullstone/lambda-bootstrap:latest"
-  target = "${aws_ecr_repository.this.repository_url}:bootstrap"
+  target = local.bootstrap_image_uri
 }

--- a/bootstrap_image.tf
+++ b/bootstrap_image.tf
@@ -3,10 +3,11 @@ data "aws_ecr_authorization_token" "temporary" {
 }
 
 provider "dockerless" {
-  registry_auth {
-    address  = data.aws_ecr_authorization_token.temporary.proxy_endpoint
-    username = data.aws_ecr_authorization_token.temporary.user_name
-    password = data.aws_ecr_authorization_token.temporary.password
+  registry_auth = {
+    "${data.aws_caller_identity.this.account_id}.dkr.ecr.${data.aws_region.this.name}.amazonaws.com" = {
+      username = data.aws_ecr_authorization_token.temporary.user_name
+      password = data.aws_ecr_authorization_token.temporary.password
+    }
   }
 }
 

--- a/capabilities.tf.tmpl
+++ b/capabilities.tf.tmpl
@@ -8,14 +8,7 @@ module "{{ .TfModuleName }}" {
   source  = "{{ .Source }}/any"
   {{ if (ne .SourceVersion "latest") }}version = "{{ .SourceVersion }}"{{ end }}
 
-  app_metadata = {
-    function_arn      = aws_lambda_function.this.arn
-    function_name     = local.resource_name
-    role_name         = aws_iam_role.executor.name
-    role_arn          = aws_iam_role.executor.arn
-    security_group_id = try(aws_security_group.this[0].id, "")
-    log_group_name    = module.logs.name
-  }
+  app_metadata = local.app_metadata
 
   {{- range $key, $value := .Variables }}
   {{ if not $value.Unused -}}

--- a/lambda.tf
+++ b/lambda.tf
@@ -4,20 +4,18 @@ locals {
   })
   env_vars = { for k, v in merge(local.standard_env_vars, var.service_env_vars) : k => v }
 
-  service_runtime   = "provided"
-  desired_image_uri = "${aws_ecr_repository.this.repository_url}:${local.app_version}"
-  current_image_uri = local.app_version != "" ? local.desired_image_uri : crane_image_tarball.bootstrap.name
+  effective_image_uri = "${aws_ecr_repository.this.repository_url}:${coalesce(local.app_version, "bootstrap")}"
 }
 
 resource "aws_lambda_function" "this" {
   function_name = local.resource_name
   role          = aws_iam_role.executor.arn
-  runtime       = local.service_runtime
+  runtime       = "provided"
   memory_size   = var.service_memory
   timeout       = var.service_timeout
   tags          = local.tags
   package_type  = "Image"
-  image_uri     = local.current_image_uri
+  image_uri     = local.effective_image_uri
 
   vpc_config {
     security_group_ids = [aws_security_group.this.id]

--- a/lambda.tf
+++ b/lambda.tf
@@ -4,7 +4,8 @@ locals {
   })
   env_vars = { for k, v in merge(local.standard_env_vars, var.service_env_vars) : k => v }
 
-  effective_image_uri = "${aws_ecr_repository.this.repository_url}:${coalesce(local.app_version, "bootstrap")}"
+  bootstrap_image_uri = "${aws_ecr_repository.this.repository_url}:bootstrap"
+  effective_image_uri = local.app_version == "" ? dockerless_remote_image.bootstrap.target : "${aws_ecr_repository.this.repository_url}:${local.app_version}"
 }
 
 resource "aws_lambda_function" "this" {

--- a/nullstone.tf
+++ b/nullstone.tf
@@ -3,6 +3,9 @@ terraform {
     ns = {
       source = "nullstone-io/ns"
     }
+    dockerless = {
+      source = "nullstone-io/dockerless"
+    }
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,8 @@
 output "region" {
-  description = "string |||"
+  description = "string ||| The region the lambda was created."
   value       = data.aws_region.this.name
 }
+
 output "deployer" {
   value = {
     name       = aws_iam_user.deployer.name
@@ -26,12 +27,12 @@ output "lambda_arn" {
 
 output "log_provider" {
   value       = "cloudwatch"
-  description = "string ||| "
+  description = "string ||| All logs are emitted to 'cloudwatch'."
 }
 
 output "log_group_name" {
   value       = module.logs.name
-  description = "string ||| "
+  description = "string ||| The name of the cloudwatch log group containing application logs."
 }
 
 output "log_reader" {
@@ -47,12 +48,12 @@ output "artifact_source" {
 
 output "image_repo_name" {
   value       = aws_ecr_repository.this.name
-  description = "string ||| "
+  description = "string ||| The name of the docker image for the application."
 }
 
 output "image_repo_url" {
   value       = aws_ecr_repository.this.repository_url
-  description = "string ||| "
+  description = "string ||| The URL for the docker image repository for the application."
 }
 
 output "image_pusher" {
@@ -68,11 +69,11 @@ output "image_pusher" {
 }
 
 output "private_urls" {
-  description = "list(string) |||"
+  description = "list(string) ||| A list of URLs only accessible inside the network."
   value       = [for url in try(local.capabilities.private_urls, []) : url["url"]]
 }
 
 output "public_urls" {
-  description = "list(string) |||"
+  description = "list(string) ||| A list of URLs accessible to the public"
   value       = [for url in try(local.capabilities.public_urls, []) : url["url"]]
 }

--- a/repository.tf
+++ b/repository.tf
@@ -2,7 +2,7 @@
 // We need to find a better way to do this
 resource "aws_ecr_repository" "this" {
   name = local.resource_name
-  tags = data.ns_workspace.this.tags
+  tags = local.tags
 }
 
 resource "aws_ecr_repository_policy" "this" {

--- a/role.tf
+++ b/role.tf
@@ -1,7 +1,7 @@
 resource "aws_iam_role" "executor" {
   name               = local.resource_name
   assume_role_policy = data.aws_iam_policy_document.executor_assume.json
-  tags               = data.ns_workspace.this.tags
+  tags               = local.tags
 }
 
 data "aws_iam_policy_document" "executor_assume" {
@@ -24,6 +24,4 @@ resource "aws_iam_role_policy_attachment" "executor_basic" {
 resource "aws_iam_role_policy_attachment" "executor_vpc" {
   role       = aws_iam_role.executor.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
-
-  count = local.has_network ? 1 : 0
 }

--- a/security-group.tf
+++ b/security-group.tf
@@ -1,10 +1,12 @@
 resource "aws_security_group" "this" {
-  name   = local.resource_name
-  vpc_id = local.vpc_id
-  tags   = merge(local.tags, { Name = local.resource_name })
+  name        = local.resource_name
+  vpc_id      = local.vpc_id
+  tags        = merge(local.tags, { Name = local.resource_name })
+  description = "Managed by Terraform"
 }
 
 resource "aws_security_group_rule" "this-https-to-world" {
+  description       = "Allow service to communicate with world over HTTPS"
   security_group_id = aws_security_group.this.id
   type              = "egress"
   protocol          = "tcp"


### PR DESCRIPTION
The lambda container service was inoperable because lambda requires the image tag to exist in the target ECR repository.
Additionally, Lambda *must* use an ECR repository.

This configures the lambda container service to load up a small bootstrap image that allows infrastructure provisioning to proceed successfully.