### PR TITLE
Configure lambda permissions inside the app module

### DIFF
--- a/capabilities.tf
+++ b/capabilities.tf
@@ -36,5 +36,23 @@ locals {
         }
       }
     ]
+
+    permissions = [
+      {
+        // required
+        sid_prefix = ""
+        action     = "lambda:InvokeFunction" // lambda:InvokeFunction | lambda:GetFunction
+        principal  = ""
+
+        // optional
+        source_arn             = ""
+        source_account         = ""
+        event_source_token     = ""
+        qualifier              = ""
+        revision_id            = ""
+        principal_org_id       = ""
+        function_url_auth_type = ""
+      }
+    ]
   }
 }

--- a/permissions.tf
+++ b/permissions.tf
@@ -1,0 +1,19 @@
+locals {
+  permissions = try(local.capabilities.permissions, [])
+}
+
+resource "aws_lambda_permission" "caps" {
+  for_each = {for p in local.permissions : p.name => p}
+
+  function_name       = aws_lambda_function.this.function_name
+  statement_id_prefix = try(each.value.sid_prefix, null)
+  action              = try(each.value.action, null)
+  principal           = try(each.value.principal, null)
+
+  source_arn             = try(each.value.source_arn, null)
+  source_account         = try(each.value.source_account, null)
+  event_source_token     = try(each.value.event_source_token, null)
+  qualifier              = try(each.value.qualifier, null)
+  principal_org_id       = try(each.value.principal_org_id, null)
+  function_url_auth_type = try(each.value.function_url_auth_type, null)
+}


### PR DESCRIPTION
This PR adds `permissions` to the capabilities contract for lambdas.

Since we started sourcing environment variables from capabilities, capabilities are created *after* the lambda function is created.
This causes `aws_lambda_permission` to fail when provisioning.

Instead, permissions are sent back to the app module.