### PR TITLE
Enable user-created secrets env vars

### DIFF
--- a/app.tf
+++ b/app.tf
@@ -10,9 +10,12 @@ locals {
 
 locals {
   app_metadata = tomap({
-    // Inject app metadata into capabilities here (e.g. security_group_name, role_name)
-    function_arn      = aws_lambda_function.this.arn
-    function_name     = local.resource_name
+    // Inject app metadata into capabilities here (e.g. security_group_id, role_name)
+    function_name = local.resource_name
+    // We can't use aws_lambda_function.this.arn because it will create a cycle lambda => env => capabilities => lambda
+    // NOTE: This *may* introduce a race condition for newly-launched lambdas
+    //    e.g. api gateway capability adds an `aws_lambda_permission` before the lambda exists
+    function_arn      = "arn:aws:lambda:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:function:${local.resource_name}"
     role_name         = aws_iam_role.executor.name
     role_arn          = aws_iam_role.executor.arn
     security_group_id = aws_security_group.this.id

--- a/capabilities.tf
+++ b/capabilities.tf
@@ -1,7 +1,15 @@
 // This file is replaced by code-generation using 'capabilities.tf.tmpl'
+// This file helps app module creators define a contract for what types of capability outputs are supported.
 locals {
   capabilities = {
     env = [
+      {
+        name  = ""
+        value = ""
+      }
+    ]
+
+    secrets = [
       {
         name  = ""
         value = ""
@@ -13,7 +21,7 @@ locals {
     // They will be flattened into list(string) when we output from this module
     private_urls = [
       {
-        value = ""
+        url = ""
       }
     ]
 
@@ -22,7 +30,7 @@ locals {
     // They will be flattened into list(string) when we output from this module
     public_urls = [
       {
-        value = ""
+        url = ""
       }
     ]
 

--- a/env.tf
+++ b/env.tf
@@ -1,0 +1,7 @@
+locals {
+  standard_env_vars = tomap({
+    NULLSTONE_ENV = data.ns_workspace.this.env_name
+  })
+  cap_env_vars = { for item in try(local.capabilities.env, []) : item.name => item.value }
+  env_vars     = merge(local.cap_env_vars, local.app_secret_ids, var.service_env_vars, local.standard_env_vars)
+}

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,9 +1,4 @@
 locals {
-  standard_env_vars = tomap({
-    NULLSTONE_ENV = data.ns_workspace.this.env_name
-  })
-  env_vars = { for k, v in merge(local.standard_env_vars, var.service_env_vars) : k => v }
-
   bootstrap_image_uri = "${aws_ecr_repository.this.repository_url}:bootstrap"
   effective_image_uri = local.app_version == "" ? dockerless_remote_image.bootstrap.target : "${aws_ecr_repository.this.repository_url}:${local.app_version}"
 }

--- a/role.tf
+++ b/role.tf
@@ -25,3 +25,38 @@ resource "aws_iam_role_policy_attachment" "executor_vpc" {
   role       = aws_iam_role.executor.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
+
+resource "aws_iam_role_policy" "executor" {
+  role   = aws_iam_role.executor.id
+  policy = data.aws_iam_policy_document.executor.json
+}
+
+locals {
+  // These are used to generate an IAM policy statement to allow the app to read the secrets
+  secret_arns                = [for as in aws_secretsmanager_secret.app_secret : as.arn]
+  secret_statement_resources = length(local.secret_arns) > 0 ? [local.secret_arns] : []
+}
+
+data "aws_iam_policy_document" "executor" {
+  statement {
+    sid       = "AllowBasicSecretsListing"
+    effect    = "Allow"
+    actions   = ["secretsmanager:ListSecrets"]
+    resources = ["*"]
+  }
+
+  dynamic "statement" {
+    for_each = local.secret_statement_resources
+
+    content {
+      sid       = "AllowReadSecrets"
+      effect    = "Allow"
+      resources = statement.value
+
+      actions = [
+        "secretsmanager:GetSecretValue",
+        "kms:Decrypt"
+      ]
+    }
+  }
+}

--- a/secrets.tf
+++ b/secrets.tf
@@ -1,0 +1,27 @@
+locals {
+  // We use `local.secret_keys` to create secret resources
+  // If we used `length(local.capabilities.secrets)`,
+  //   terraform would complain about not knowing count of the resource until after apply
+  // This is because the name of secrets isn't computed in the modules; only the secret value
+  cap_secrets = { for secret in try(local.capabilities.secrets, []) : secret["name"] => secret["value"] }
+  all_secrets = merge(local.cap_secrets, var.service_secrets)
+  secret_keys = can(nonsensitive(keys(local.all_secrets))) ? toset(nonsensitive(keys(local.all_secrets))) : toset(keys(local.all_secrets))
+
+  // Since lambda does not have secret injection, we are going to add a list of env vars mapping the secret ids
+  // e.g. POSTGRES_URL => POSTGRES_URL_SECRET_ID = <secret-id>
+  app_secret_ids = { for key in local.secret_keys : "${key}_SECRET_ID" => aws_secretsmanager_secret.app_secret[key].id }
+}
+
+resource "aws_secretsmanager_secret" "app_secret" {
+  for_each = local.secret_keys
+
+  name = "${local.resource_name}/${each.value}"
+  tags = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "app_secret" {
+  for_each = local.secret_keys
+
+  secret_id     = aws_secretsmanager_secret.app_secret[each.value].id
+  secret_string = local.all_secrets[each.value]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,16 @@ It is dangerous to put sensitive information in this variable because they are n
 EOF
 }
 
+variable "service_secrets" {
+  type        = map(string)
+  default     = {}
+  sensitive   = true
+  description = <<EOF
+The sensitive environment variables to inject into the service.
+These are typically used to configure a service per environment.
+EOF
+}
+
 variable "service_timeout" {
   type        = number
   default     = 3


### PR DESCRIPTION
This adds general secrets support including capabilities secrets.

This adds a `service_secrets` sensitive variable.
These secrets are combined with capability secrets to inject into app via secrets manager.
