### PR TITLE
C1084 cap namespace

### DIFF
--- a/capabilities.tf
+++ b/capabilities.tf
@@ -1,6 +1,18 @@
 // This file is replaced by code-generation using 'capabilities.tf.tmpl'
 // This file helps app module creators define a contract for what types of capability outputs are supported.
 locals {
+  cap_modules = [
+    {
+      id         = 0
+      namespace  = ""
+      env_prefix = ""
+      outputs    = {}
+    }
+  ]
+
+  cap_env_vars = {}
+  cap_secrets  = {}
+
   capabilities = {
     env = [
       {

--- a/capabilities.tf
+++ b/capabilities.tf
@@ -74,5 +74,19 @@ locals {
         function_url_auth_type = ""
       }
     ]
+
+    event_sources = [
+      {
+        // required
+        name       = "" // used to uniquely identify the event source
+        source_arn = ""
+
+        // optional
+        enabled           = true
+        batch_size        = null // number
+        starting_position = null // string
+        topic             = []   // list(string)
+      }
+    ]
   }
 }

--- a/capabilities.tf.tmpl
+++ b/capabilities.tf.tmpl
@@ -6,7 +6,9 @@ provider "ns" {
 
 module "{{ .TfModuleName }}" {
   source  = "{{ .Source }}/any"
-  {{ if (ne .SourceVersion "latest") }}version = "{{ .SourceVersion }}"{{ end }}
+  {{- if (ne .SourceVersion "latest") }}
+  version = "{{ .SourceVersion }}"
+  {{- end }}
 
   app_metadata = local.app_metadata
 
@@ -26,10 +28,35 @@ module "caps" {
 }
 
 locals {
-  modules       = [
+  modules      = [
 {{- range $index, $element := .ExceptNeedsDestroyed.TfModuleAddrs -}}
 {{ if $index }}, {{ end }}{{ $element }}
 {{- end -}}
 ]
-  capabilities  = module.caps.outputs
+  capabilities = module.caps.outputs
+
+  cap_modules = [
+{{- range $index, $element := .ExceptNeedsDestroyed }}
+    {{ if $index }}, {{ end }}{
+      id         = {{ $element.Id }}
+      namespace  = "{{ $element.Namespace }}"
+      env_prefix = "{{ $element.EnvPrefix }}"
+      outputs    = {{ $element.TfModuleAddr }}
+    }
+{{- end }}
+  ]
+}
+
+locals {
+  cap_env_vars = merge([
+    for mod in local.cap_modules : {
+      for item in lookup(mod.outputs, "env", []) : "${mod.env_prefix}${item.name}" => item.value
+    }
+  ]...)
+
+  cap_secrets = merge([
+    for mod in local.cap_modules : {
+      for item in lookup(mod.outputs, "secrets", []) : "${mod.env_prefix}${item.name}" => item.value
+    }
+  ]...)
 }

--- a/env.tf
+++ b/env.tf
@@ -2,5 +2,5 @@ locals {
   standard_env_vars = tomap({
     NULLSTONE_ENV = data.ns_workspace.this.env_name
   })
-  env_vars     = merge(local.cap_env_vars, local.app_secret_ids, var.service_env_vars, local.standard_env_vars)
+  env_vars = merge(local.standard_env_vars, local.cap_env_vars, local.app_secret_ids, var.service_env_vars)
 }

--- a/env.tf
+++ b/env.tf
@@ -2,6 +2,5 @@ locals {
   standard_env_vars = tomap({
     NULLSTONE_ENV = data.ns_workspace.this.env_name
   })
-  cap_env_vars = { for item in try(local.capabilities.env, []) : item.name => item.value }
   env_vars     = merge(local.cap_env_vars, local.app_secret_ids, var.service_env_vars, local.standard_env_vars)
 }

--- a/event_sources.tf
+++ b/event_sources.tf
@@ -1,0 +1,19 @@
+locals {
+  event_sources = merge(flatten([
+    for mod in local.cap_modules : {
+      for item in lookup(mod.outputs, "event_sources", []) : "${mod.id}_${item.name}" => item
+    }
+  ])...)
+}
+
+resource "aws_lambda_event_source_mapping" "caps" {
+  for_each = local.event_sources
+
+  function_name    = aws_lambda_function.this.function_name
+  event_source_arn = each.value.source_arn
+  enabled          = try(each.value.enabled, true)
+
+  batch_size        = try(each.value.batch_size, null)
+  starting_position = try(each.value.starting_position, null)
+  topics            = try(each.value.topics, null)
+}

--- a/permissions.tf
+++ b/permissions.tf
@@ -1,9 +1,13 @@
 locals {
-  permissions = try(local.capabilities.permissions, [])
+  permissions = merge(flatten([
+    for mod in local.cap_modules : {
+      for item in lookup(mod.outputs, "permissions", []) : "${mod.id}_${item.sid_prefix}" => item
+    }
+  ])...)
 }
 
 resource "aws_lambda_permission" "caps" {
-  for_each = {for p in local.permissions : p.name => p}
+  for_each = local.permissions
 
   function_name       = aws_lambda_function.this.function_name
   statement_id_prefix = try(each.value.sid_prefix, null)

--- a/secrets.tf
+++ b/secrets.tf
@@ -3,7 +3,6 @@ locals {
   // If we used `length(local.capabilities.secrets)`,
   //   terraform would complain about not knowing count of the resource until after apply
   // This is because the name of secrets isn't computed in the modules; only the secret value
-  cap_secrets = { for secret in try(local.capabilities.secrets, []) : secret["name"] => secret["value"] }
   all_secrets = merge(local.cap_secrets, var.service_secrets)
   secret_keys = can(nonsensitive(keys(local.all_secrets))) ? toset(nonsensitive(keys(local.all_secrets))) : toset(keys(local.all_secrets))
 


### PR DESCRIPTION
Update the lamba service to differentiate between env vars with the same name by utilizing a capability's namespace and env prefix.

Additionally:
- Fix lambda permission creation issue (`known after apply`)
- Fix event source mappings (`function does not exist`) by moving into app module (https://github.com/nullstone-modules/aws-sqs-lambda-trigger/pull/2)