### PR TITLE
F1945 lambda secret refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.12 (Aug 19, 2024)
+* Added the ability to reference existing secrets using interpolation.
+* e.g. "{{ secret(arn-of-existing-secret) }}"
+
 # 0.4.11 (Feb 10, 2024)
 * Added permissions to list image tags in image repository.
 

--- a/env_vars.tf
+++ b/env_vars.tf
@@ -44,7 +44,8 @@ data "ns_secret_keys" "this" {
 }
 
 locals {
-  secret_keys  = data.ns_secret_keys.this.secret_keys
-  all_secrets  = data.ns_env_variables.this.secrets
-  all_env_vars = merge(data.ns_env_variables.this.env_variables, local.app_secret_ids)
+  secret_keys          = data.ns_secret_keys.this.secret_keys
+  all_secrets          = data.ns_env_variables.this.secrets
+  existing_secret_refs = data.ns_env_variables.this.secret_refs
+  all_env_vars         = merge(data.ns_env_variables.this.env_variables, local.app_secret_ids, local.existing_secret_refs)
 }

--- a/role.tf
+++ b/role.tf
@@ -33,8 +33,10 @@ resource "aws_iam_role_policy" "executor" {
 
 locals {
   // These are used to generate an IAM policy statement to allow the app to read the secrets
+  existing_arns              = values(local.existing_secret_refs)
   secret_arns                = [for as in aws_secretsmanager_secret.app_secret : as.arn]
-  secret_statement_resources = length(local.secret_arns) > 0 ? [local.secret_arns] : []
+  all_arns                   = concat(local.secret_arns, local.existing_arns)
+  secret_statement_resources = length(local.all_arns) > 0 ? [local.all_arns] : []
 }
 
 data "aws_iam_policy_document" "executor" {

--- a/secrets.tf
+++ b/secrets.tf
@@ -1,8 +1,7 @@
 locals {
   // Since lambda does not have secret injection, we are going to add a list of env vars mapping the secret ids
   // e.g. POSTGRES_URL => POSTGRES_URL_SECRET_ID = <secret-id>
-  app_secret_ids  = { for key in local.secret_keys : "${key}_SECRET_ID" => aws_secretsmanager_secret.app_secret[key].id }
-  app_secret_arns = [for key in local.secret_keys : aws_secretsmanager_secret.app_secret[key].arn]
+  app_secret_ids = { for key in local.secret_keys : "${key}_SECRET_ID" => aws_secretsmanager_secret.app_secret[key].id }
 }
 
 resource "aws_secretsmanager_secret" "app_secret" {
@@ -19,35 +18,4 @@ resource "aws_secretsmanager_secret_version" "app_secret" {
 
   secret_id     = aws_secretsmanager_secret.app_secret[each.value].id
   secret_string = local.all_secrets[each.value]
-}
-
-resource "aws_iam_role_policy_attachment" "lambda-secrets" {
-  count = length(local.secret_keys) > 0 ? 1 : 0
-
-  role       = aws_iam_role.executor.name
-  policy_arn = aws_iam_policy.secrets[count.index].arn
-}
-
-resource "aws_iam_policy" "secrets" {
-  count = length(local.secret_keys) > 0 ? 1 : 0
-
-  name   = local.resource_name
-  policy = data.aws_iam_policy_document.secrets.json
-}
-
-data "aws_iam_policy_document" "secrets" {
-  dynamic "statement" {
-    for_each = length(local.secret_keys) > 0 ? [local.app_secret_arns] : []
-
-    content {
-      sid       = "AllowReadSecrets"
-      effect    = "Allow"
-      resources = statement.value
-  
-      actions = [
-        "secretsmanager:GetSecretValue",
-        "kms:Decrypt"
-      ]
-    }
-  }
 }


### PR DESCRIPTION
This PR adds support for references to existing secrets to this module.

If a user sets an env var to the value "{{ secret(arn) }}", we were just discarding this env var. With this PR, the env var will now be included and have a value set to the arn passed in. We also add permissions for the app to be able to the secret from secrets manager.